### PR TITLE
Installing pip package in develop mode on every run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,6 @@ RUN pip install -e /opt/shmir
 RUN pip install -r /opt/shmir/test-requirements.txt
 RUN pip install tox
 
+COPY start.sh /
+
 ENV C_FORCE_ROOT true

--- a/fig.yml
+++ b/fig.yml
@@ -1,7 +1,7 @@
 shmir:
     build: .
     working_dir: /opt/shmir
-    command: supervisord -c /etc/supervisor/supervisord.conf
+    command: /start.sh
     volumes:
         - .:/opt/shmir
         - etc/shmir:/etc/shmir

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# If we mount host's directory as Docker volume, it will not contain
+# any egg-related files. Therefore we should ensure that shmir is installed
+# in "develop" mode every time.
+pip install -e /opt/shmir
+
+exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
sh-miR designer is usually ran in Docker container with
volume mounted from host, to upgrade the code without
rebuilding containers. Directory on host doesn't contain
egg files which are created on pip installation, therefore
we have to install package on every run.